### PR TITLE
refactor: 상품조회 관련 기능 리팩토링

### DIFF
--- a/src/main/java/com/shop/demo/dto/query/ProductInfoDto.java
+++ b/src/main/java/com/shop/demo/dto/query/ProductInfoDto.java
@@ -1,5 +1,7 @@
 package com.shop.demo.dto.query;
 
+import com.shop.demo.products.Product;
+import com.shop.demo.products.ProductOption;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +10,6 @@ import lombok.Setter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@AllArgsConstructor
 @Getter
 @Setter
 public class ProductInfoDto {
@@ -25,6 +26,24 @@ public class ProductInfoDto {
         this.title = title;
         this.price = price;
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+//    @Builder(builderMethodName = "builder2")
+    public ProductInfoDto(Long id, String title, long price, List<String> options, String thumbnailUrl) {
+        this.id = id;
+        this.title = title;
+        this.price = price;
+        this.options = options;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public static ProductInfoDto toDto(Product product) {
+        List<String> options = product.getOptions() // 2번째 쿼리
+                .stream()
+                .map(ProductOption::getOptionName)
+                .collect(Collectors.toList());
+
+        return new ProductInfoDto(product.getId(), product.getTitle(), product.getPrice().getMoney(), options, product.getImageUrl());
     }
 
     public void setOptions(List<OptionNameDto> dtos) {

--- a/src/main/java/com/shop/demo/products/Product.java
+++ b/src/main/java/com/shop/demo/products/Product.java
@@ -3,6 +3,7 @@ package com.shop.demo.products;
 import com.shop.demo.common.BaseTimeEntity;
 import com.shop.demo.common.Money;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
 import java.util.ArrayList;

--- a/src/main/java/com/shop/demo/products/controller/ProductApiController.java
+++ b/src/main/java/com/shop/demo/products/controller/ProductApiController.java
@@ -19,8 +19,7 @@ public class ProductApiController {
 
     @GetMapping
     public ResponseEntity getRecentProducts(@PageableDefault(size = 12, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-//        return new ResponseEntity(productQueryService.getRecentProducts(pageable), HttpStatus.OK);
-        return new ResponseEntity(productQueryService.getRecentProducts2(pageable), HttpStatus.OK);
+        return new ResponseEntity(productQueryService.getRecentProducts(pageable), HttpStatus.OK);
     }
 
     @GetMapping("/category/{category}")

--- a/src/main/java/com/shop/demo/products/controller/ProductApiController.java
+++ b/src/main/java/com/shop/demo/products/controller/ProductApiController.java
@@ -19,7 +19,8 @@ public class ProductApiController {
 
     @GetMapping
     public ResponseEntity getRecentProducts(@PageableDefault(size = 12, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-        return new ResponseEntity(productQueryService.getRecentProducts(pageable), HttpStatus.OK);
+//        return new ResponseEntity(productQueryService.getRecentProducts(pageable), HttpStatus.OK);
+        return new ResponseEntity(productQueryService.getRecentProducts2(pageable), HttpStatus.OK);
     }
 
     @GetMapping("/category/{category}")

--- a/src/main/java/com/shop/demo/products/repository/ProductRepository.java
+++ b/src/main/java/com/shop/demo/products/repository/ProductRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -34,4 +35,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @EntityGraph(attributePaths = {"options"})
     Optional<Product> findById(Long productId);
 
+    //distinct 는 한 줄이 완전히 똑같을 때 만 날라감 , id만 같을 경우에는 안됨 근데 JPA는 해줌(어플리케이션 단에서!, 디비단 아님!)
+    @Query("select p from Product p")
+    Page<Product> findProductsInfo2(Pageable pageable);
 }

--- a/src/main/java/com/shop/demo/products/repository/ProductRepository.java
+++ b/src/main/java/com/shop/demo/products/repository/ProductRepository.java
@@ -23,10 +23,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Page<Product> findByCategory(@Param("category") Category category, Pageable pageable);
 
-    @Query(value = "select new com.shop.demo.dto.query.ProductInfoDto(p.id, p.title, p.price.money, p.imageUrl) " +
+    @Query(value = "select p " +
             "from Product p " +
             "where p.title like %:keyword%")
-    Page<ProductInfoDto> findProductsInfoInKeyword(@Param(("keyword")) String keyword, Pageable pageable);
+    Page<Product> findProductsInfoInKeyword(@Param(("keyword")) String keyword, Pageable pageable);
 
     @Override
     @EntityGraph(attributePaths = {"options"})

--- a/src/main/java/com/shop/demo/products/repository/ProductRepository.java
+++ b/src/main/java/com/shop/demo/products/repository/ProductRepository.java
@@ -21,10 +21,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "from Product p")
     Page<ProductInfoDto> findProductsInfo(Pageable pageable);
 
-    @Query(value = "select new com.shop.demo.dto.query.ProductInfoDto(p.id, p.title, p.price.money, p.imageUrl) " +
-            "from Product p " +
-            "where p.category = :category")
-    Page<ProductInfoDto> findProductsInfoByCategory(@Param("category") Category category, Pageable pageable);
+    Page<Product> findByCategory(@Param("category") Category category, Pageable pageable);
 
     @Query(value = "select new com.shop.demo.dto.query.ProductInfoDto(p.id, p.title, p.price.money, p.imageUrl) " +
             "from Product p " +

--- a/src/main/java/com/shop/demo/products/service/query/ProductQueryService.java
+++ b/src/main/java/com/shop/demo/products/service/query/ProductQueryService.java
@@ -29,7 +29,7 @@ public class ProductQueryService {
 
 
     // 방법 1 DTO로 조회하고 반환
-    public Page<ProductInfoDto> getRecentProducts(Pageable pageable) {
+    public Page<ProductInfoDto> getRecentProductsV1(Pageable pageable) {
         // 쿼리 2번
         Page<ProductInfoDto> products = productRepository.findProductsInfo(pageable);
         getProductOptions(products);
@@ -37,8 +37,8 @@ public class ProductQueryService {
         return products;
     }
 
-    // 방법 2 엔티티로 조회하고 DTO로 변환 -> oneTomany는 페이징 안됨
-    public Page<ProductInfoDto> getRecentProducts2(Pageable pageable) {
+    // 방법 2 엔티티로 조회하고 DTO로 변환 -> oneTomany는 페이징 안됨(MultiBegException)
+    public Page<ProductInfoDto> getRecentProducts(Pageable pageable) {
         // 쿼리 1번
         Page<Product> products = productRepository.findProductsInfo2(pageable);
 
@@ -49,10 +49,9 @@ public class ProductQueryService {
     public Page<ProductInfoDto> getProductsByCategory(String categoryName, Pageable pageable) {
         Category category = Category.getCategoryByName(categoryName);
 
-        Page<ProductInfoDto> products = productRepository.findProductsInfoByCategory(category, pageable);
-        getProductOptions(products);
+        Page<Product> products = productRepository.findByCategory(category, pageable);
 
-        return products;
+        return products.map(ProductInfoDto::toDto);
     }
 
     public Page<ProductInfoDto> getProductsContainsKeyword(String keyword, Pageable pageable) {

--- a/src/main/java/com/shop/demo/products/service/query/ProductQueryService.java
+++ b/src/main/java/com/shop/demo/products/service/query/ProductQueryService.java
@@ -28,11 +28,22 @@ public class ProductQueryService {
     private final ProductOptionRepository productOptionRepository;
 
 
+    // 방법 1 DTO로 조회하고 반환
     public Page<ProductInfoDto> getRecentProducts(Pageable pageable) {
+        // 쿼리 2번
         Page<ProductInfoDto> products = productRepository.findProductsInfo(pageable);
         getProductOptions(products);
 
         return products;
+    }
+
+    // 방법 2 엔티티로 조회하고 DTO로 변환 -> oneTomany는 페이징 안됨
+    public Page<ProductInfoDto> getRecentProducts2(Pageable pageable) {
+        // 쿼리 1번
+        Page<Product> products = productRepository.findProductsInfo2(pageable);
+
+        // 쿼리 2번 (in 절)
+       return products.map(ProductInfoDto::toDto);
     }
 
     public Page<ProductInfoDto> getProductsByCategory(String categoryName, Pageable pageable) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,9 +8,11 @@ spring.datasource.username=root
 spring.datasource.password=12345678
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.show-sql=true
+#spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
+
+spring.jpa.properties.hibernate.default_batch_fetch_size=100
 
 spring.datasource.initialization-mode=always
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect


### PR DESCRIPTION
[구현기능]
- 기존에 Repository에서 DTO타입으로 조회하던 방식 대신 엔티티로 조회 후 DTO로 변환

[새로 알게된 점]
- OneToMany를 Fetch Join 하게 되면 디비에서 데이터가 뻥튀기 된 상태로 오고 그걸 ***어플리케이션 단***에서 JPA가 조작해서 데이터를 이쁘게 만든다!
- MultipleBagFetchException 을 해결하기 위해 batch_fetch_size 적용

[느낀점]
***DTO로 조회 vs Entity로 조회***
공통점: 두 방법 다 쿼리는 2번

- Repository에서 상품조회용 DTO로 바로 조회 (Page<상품 DTO>는 조회된 상태)
  1.  DTO의 id만을 가진 List를 stream으로 만들고
  2. in절에 그 리스트를 넣어 조회된 상품옵션 DTO List를  조회
  3. stream을 통해 DTO List를 productId 로 groupBy 하여 Map으로 만들고 
  4. 상품 DTO 에 끼워넣는다.
    `이 방법은 id list와 groupby를 추가적으로 만들어 주기 때문에 코드가 늘어남`

<br>

- Repository에서 상품 바로 조회 후 DTO로 변환 (Page<상품>은 이미 조회된 상태)
   1. 상품 조회된 결과를 .map하여 DTO로 변환
     1.1 DTO로 변환하면서 상품옵션 엔티티를 조회(batch_fetch_size로 in 절을 통해 쿼리 1번으로 상품옵션들 조회)
     1.2 상품옵션들을 DTO로 변환
- 얘가 훨씬 깔끔해 보여서 엔티티 반환후 변환 방식을 채택!
 